### PR TITLE
Feature: possibility to define a date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ This input file is used in [this publication](https://doi.org/10.1109/PTC.2019.8
 ### Spreadsheet input files
 It is also possible to use spreadsheets as input files. To do so you need to run the `ramp.py` file which is at the root of the repository with the option `-i`: `python ramp.py -i <path to .xlsx input file>`. If you already know how many profile you want to simulate you can indicate it with the `-n` option: `python ramp.py -i <path to .xlsx input file> -n 10` will simulate 10 profiles. Note that you can use this option without providing a `.xlsx` input file with the `-i` option, this will then be equivalent to running `python ramp_run.py` from the `ramp` folder without being prompted for the number of profile within the console.
 
+### Year simulation with different input parameters per month
+
+The following command (for windows user use `\` instead of `/`)
+`python ramp.py -i ramp/input_files/ -n 3 -y 2022`
+
+will simulate 3 daily profiles and average them to get a daily profile for each day of the whole year 2022, the averaged daily profiles are concatenated to a long timeseries for the year with minute resolution. It expects that 12 independant .xlsx input files are located in the folder `ramp/input_files/` and sorted numerically by month number (the sorted order is printed out at the execution of the function for the user to check)
+The results will be saved in the files `'yearly_profile_min_resolution.csv'` and `'yearly_profile_hour_resolution.csv'` for further data analysis for the time being (let us know in https://github.com/rl-institut/RAMP/issues/11 how you would like to be able to modify the file names and/or location)
+
 ### Convert python input files to xlsx
 If you have existing python input files, you can convert them to spreadsheet. To do so, go to `ramp` folder and run
 

--- a/ramp.py
+++ b/ramp.py
@@ -1,8 +1,13 @@
 import argparse
 import datetime
+import os.path
+import time
+
 import pandas as pd
+import numpy as np
 from ramp.ramp_run import run_usecase
 
+BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 parser = argparse.ArgumentParser(
     prog="python ramp_run.py", description="Execute RAMP code"
@@ -44,14 +49,23 @@ parser.add_argument(
     help="Date of end in YYYY-MM-DD format",
 )
 
-if __name__ == "__main__":
+parser.add_argument(
+    "--ext",
+    dest="extension",
+    type=str,
+    help="Format of input files",
+    default="xlsx"
+)
 
+if __name__ == "__main__":
+    ts = time.time()
     args = vars(parser.parse_args())
     fnames = args["fname_path"]
     num_profiles = args["num_profiles"]
     # Define which input files should be considered and run.
     date_start = args["date_start"]
     date_end = args["date_end"]
+    ext = args["extension"]
 
     years = args["years"]
 
@@ -62,17 +76,37 @@ if __name__ == "__main__":
         if date_end is None:
             date_end = datetime.date(date_start.year, 12, 31)
 
+    month_files = False
+
     if years is not None:
         if date_start is not None or date_end is not None:
             raise ValueError("You cannot use the option -y in combinaison with --date-start and/or --date-end")
         else:
             date_start = datetime.date(years[0], 1, 1)
             date_end = datetime.date(years[-1], 12, 31)
+        if len(years) == 1 and fnames is not None:
+            # This special combination (option -y with only 1 year and option -i with a directory as parameter)
+            # Triggers the special mode "one input file per month"
+            if os.path.isdir(fnames[0]):
+                fnames = [os.path.join(fnames[0], f) for f in os.listdir(fnames[0]) if f.endswith(ext)]
+                fnames.sort(key=lambda f: int(''.join(filter(str.isdigit, f))))
+
+                if len(fnames) == 12:
+                    print("The following input files were found and will be used in this exact order for month inputs")
+                    print("\n".join(fnames))
+                    month_files = True
+                    year = years[0]
+                else:
+                    raise ValueError(f"You want to simulate a whole year, yet the folder {fnames[0]} only contains {len(month_files)} out of the 12 monthes required ")
+            else:
+                print("You selected a single year but the input path is not a folder.")
+
 
     if date_start is not None and date_end is not None:
         days = pd.date_range(start=date_start, end=date_end)
     else:
         days = None
+
 
     if fnames is None:
         print("Please provide path to input file with option -i, \n\nDefault to old version of RAMP input files\n")
@@ -101,6 +135,27 @@ if __name__ == "__main__":
                         "The number of profiles parameters  should match the number of input files provided")
         else:
             num_profiles = [None] * len(fnames)
+        if month_files is True:
+            year_profile = []
+            for i, fname in enumerate(fnames):
+                month_start = datetime.date(year, i+1, 1)
+                month_end = datetime.date(year, i+1, pd.Period(month_start, freq="D").days_in_month)
+                days = pd.date_range(start=month_start, end=month_end, freq='D')
+                monthly_profiles = run_usecase(fname=fname, num_profiles=num_profiles[i], days=days, plot=False)
+                year_profile.append(np.hstack(monthly_profiles))
 
-        for i, fname in enumerate(fnames):
-            run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)
+            # Create a dataFrame to save the year profile with timestamps every minutes
+            series_frame = pd.DataFrame(
+                np.hstack(year_profile),
+                index=pd.date_range(start=f"{year}-1-1", end=f"{year}-12-31 23:59", freq="T")
+            )
+            # Save to minute and hour resolution
+            # TODO let the user choose where to save the files/file_name, make sure the user wants to overwrite the file
+            # if it already exists
+            series_frame.to_csv(os.path.join(BASE_PATH, 'yearly_profile_min_resolution.csv'))
+            series_frame.resample("H").sum().to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
+        else:
+            for i, fname in enumerate(fnames):
+                run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)
+
+    print(f" Time elapsed: {time.time()-ts}")

--- a/ramp.py
+++ b/ramp.py
@@ -103,4 +103,4 @@ if __name__ == "__main__":
             num_profiles = [None] * len(fnames)
 
         for i, fname in enumerate(fnames):
-            run_usecase(fname=fname, num_profiles=num_profiles[i])
+            run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)

--- a/ramp.py
+++ b/ramp.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
             # TODO let the user choose where to save the files/file_name, make sure the user wants to overwrite the file
             # if it already exists
             series_frame.to_csv(os.path.join(BASE_PATH, 'yearly_profile_min_resolution.csv'))
-            series_frame.resample("H").sum().to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
+            series_frame.resample("H").mean().to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
         else:
             for i, fname in enumerate(fnames):
                 run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)

--- a/ramp.py
+++ b/ramp.py
@@ -88,7 +88,8 @@ if __name__ == "__main__":
             # This special combination (option -y with only 1 year and option -i with a directory as parameter)
             # Triggers the special mode "one input file per month"
             if os.path.isdir(fnames[0]):
-                fnames = [os.path.join(fnames[0], f) for f in os.listdir(fnames[0]) if f.endswith(ext)]
+                dir_path = fnames[0]
+                fnames = [os.path.join(dir_path, f) for f in os.listdir(fnames[0]) if f.endswith(ext)]
                 fnames.sort(key=lambda f: int(''.join(filter(str.isdigit, f))))
 
                 if len(fnames) == 12:
@@ -97,7 +98,7 @@ if __name__ == "__main__":
                     month_files = True
                     year = years[0]
                 else:
-                    raise ValueError(f"You want to simulate a whole year, yet the folder {fnames[0]} only contains {len(month_files)} out of the 12 monthes required ")
+                    raise ValueError(f"You want to simulate a whole year, yet the folder {dir_path} only contains {len(fnames)} out of the 12 monthes required")
             else:
                 print("You selected a single year but the input path is not a folder.")
 

--- a/ramp.py
+++ b/ramp.py
@@ -1,5 +1,6 @@
 import argparse
-
+import datetime
+import pandas as pd
 from ramp.ramp_run import run_usecase
 
 
@@ -21,6 +22,27 @@ parser.add_argument(
     help="number of profiles to be generated",
 )
 
+parser.add_argument(
+    "-y",
+    dest="years",
+    nargs="+",
+    type=int,
+    help="Years for which one should generate demand profiles",
+)
+
+parser.add_argument(
+    "--start-date",
+    dest="date_start",
+    type=datetime.date.fromisoformat,
+    help="Date of start in YYYY-MM-DD format",
+)
+
+parser.add_argument(
+    "--end-date",
+    dest="date_end",
+    type=datetime.date.fromisoformat,
+    help="Date of end in YYYY-MM-DD format",
+)
 
 if __name__ == "__main__":
 
@@ -28,6 +50,29 @@ if __name__ == "__main__":
     fnames = args["fname_path"]
     num_profiles = args["num_profiles"]
     # Define which input files should be considered and run.
+    date_start = args["date_start"]
+    date_end = args["date_end"]
+
+    years = args["years"]
+
+    if date_start is None:
+        if date_end is not None:
+            date_start = datetime.date(date_end.year, 1, 1)
+    else:
+        if date_end is None:
+            date_end = datetime.date(date_start.year, 12, 31)
+
+    if years is not None:
+        if date_start is not None or date_end is not None:
+            raise ValueError("You cannot use the option -y in combinaison with --date-start and/or --date-end")
+        else:
+            date_start = datetime.date(years[0], 1, 1)
+            date_end = datetime.date(years[-1], 12, 31)
+
+    if date_start is not None and date_end is not None:
+        days = pd.date_range(start=date_start, end=date_end)
+    else:
+        days = None
 
     if fnames is None:
         print("Please provide path to input file with option -i, \n\nDefault to old version of RAMP input files\n")

--- a/ramp.py
+++ b/ramp.py
@@ -154,7 +154,13 @@ if __name__ == "__main__":
             # TODO let the user choose where to save the files/file_name, make sure the user wants to overwrite the file
             # if it already exists
             series_frame.to_csv(os.path.join(BASE_PATH, 'yearly_profile_min_resolution.csv'))
-            series_frame.resample("H").mean().to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
+            resampled = pd.DataFrame()
+
+            resampled["mean"] = series_frame.resample("H").mean()
+            resampled["max"] = series_frame.resample("H").max()
+            resampled["min"] = series_frame.resample("H").min()
+            #TODO add more columns with other resampled functions (do this in Jupyter)
+            resampled.to_csv(os.path.join(BASE_PATH, 'yearly_profile_hourly_resolution.csv'))
         else:
             for i, fname in enumerate(fnames):
                 run_usecase(fname=fname, num_profiles=num_profiles[i], days=days)

--- a/ramp/core/core.py
+++ b/ramp/core/core.py
@@ -244,7 +244,7 @@ class User:
             name=name,
         )
 
-    def generate_single_load_profile(self, prof_i, peak_time_range, Year_behaviour):
+    def generate_single_load_profile(self, prof_i, peak_time_range, day_type):
         """Generates a load profile for a single user taking all its appliances into consideration
 
         Parameters
@@ -253,8 +253,8 @@ class User:
             ith profile requested by the user
         peak_time_range: numpy array
             randomised peak time range calculated using calc_peak_time_range function
-        Year_behaviour: numpy array
-            array consisting of a yearly pattern of weekends and weekdays peak_time_range
+        day_type: int
+            0 for a week day or 1 for a weekend day
         """
 
         single_load = np.zeros(1440)
@@ -271,7 +271,7 @@ class User:
                      # evaluates if daily preference coincides with the randomised daily preference number
                      or (App.pref_index != 0 and rand_daily_pref != App.pref_index)
                      # checks if the app is allowed in the given yearly behaviour pattern
-                     or App.wd_we_type not in [Year_behaviour[prof_i], 2])
+                     or App.wd_we_type not in [day_type, 2])
             ):
                 continue
 
@@ -313,7 +313,7 @@ class User:
             single_load = single_load + App.daily_use  # adds the Appliance load profile to the single User load profile
         return single_load
 
-    def generate_aggregated_load_profile(self, prof_i, peak_time_range, Year_behaviour):
+    def generate_aggregated_load_profile(self, prof_i, peak_time_range, day_type):
         """Generates an aggregated load profile from single load profile of each user
 
             Each single load profile has its own separate randomisation
@@ -324,8 +324,8 @@ class User:
             ith profile requested by the user
         peak_time_range: numpy array
             randomised peak time range calculated using calc_peak_time_range function
-        Year_behaviour: numpy array
-            array consisting of a yearly pattern of weekends and weekdays peak_time_range
+        day_type: int
+            0 for a week day or 1 for a weekend day
 
         Returns
         -------
@@ -336,7 +336,7 @@ class User:
         self.load = np.zeros(1440)  # initialise empty load for User instance
         for _ in range(self.num_users):
             # iterates for every single user within a User class.
-            self.load = self.load + self.generate_single_load_profile(prof_i, peak_time_range, Year_behaviour)
+            self.load = self.load + self.generate_single_load_profile(prof_i, peak_time_range, day_type)
 
 
 class Appliance:

--- a/ramp/core/initialise.py
+++ b/ramp/core/initialise.py
@@ -7,15 +7,6 @@ import importlib
 from ramp.core.core import UseCase
 
 
-def yearly_pattern():
-    """Definition of a yearly pattern of weekends and weekdays, in case some appliances have specific wd/we behaviour"""
-
-    year_behaviour = np.zeros(365)
-    year_behaviour[5:365:7] = 1
-    year_behaviour[6:365:7] = 1
-
-    return year_behaviour
-
 
 def user_defined_inputs(j=None, fname=None):
     """Imports an input file and returns a processed user_list
@@ -64,7 +55,6 @@ def initialise_inputs(j=None, fname=None, num_profiles=None):
 
     """
 
-    year_behaviour = yearly_pattern()
     user_list = user_defined_inputs(j, fname)
 
     peak_enlarge = 0.15  # percentage random enlargement or reduction of peak time range length, corresponds to \delta_{peak} in [1], p.7
@@ -76,4 +66,4 @@ def initialise_inputs(j=None, fname=None, num_profiles=None):
         )
         print("Please wait...")
 
-    return (peak_enlarge, year_behaviour, user_list, num_profiles)
+    return (peak_enlarge, user_list, num_profiles)

--- a/ramp/core/stochastic_process.py
+++ b/ramp/core/stochastic_process.py
@@ -69,7 +69,7 @@ def stochastic_process(j=None, fname=None, num_profiles=None, day_type=0):
     # creates an empty list to store the results of each code run, i.e. each stochastically generated profile
     profiles = []
 
-    peak_enlarge, year_behaviour, user_list, num_profiles = initialise_inputs(j, fname, num_profiles)
+    peak_enlarge, user_list, num_profiles = initialise_inputs(j, fname, num_profiles)
 
     # Calculation of the peak time range, which is used to discriminate between off-peak
     # and on-peak coincident switch-on probability, corresponds to step 1. of [1], p.6

--- a/ramp/core/stochastic_process.py
+++ b/ramp/core/stochastic_process.py
@@ -52,10 +52,13 @@ def calc_peak_time_range(user_list, peak_enlarge=0.15):
     return np.arange(peak_time - rand_peak_enlarge, peak_time + rand_peak_enlarge)
 
 
-def stochastic_process(j=None, fname=None, num_profiles=None):
+def stochastic_process(j=None, fname=None, num_profiles=None, day_type=0):
     """Generate num_profiles load profile for the usecase
 
         Covers steps 1. and 2. of the algorithm described in [1], p.6-7
+
+    day_type: int
+        0 for a week day or 1 for a weekend day
 
     Notes
     -----
@@ -79,11 +82,11 @@ def stochastic_process(j=None, fname=None, num_profiles=None):
         # for each User instance generate a load profile, iterating through all user of this instance and
         # all appliances they own, corresponds to step 2. of [1], p.7
         for user in user_list:
-            user.generate_aggregated_load_profile(prof_i, peak_time_range, year_behaviour)
+            user.generate_aggregated_load_profile(prof_i, peak_time_range, day_type)
             # aggregate the user load to the usecase load
             usecase_load = usecase_load + user.load
         profiles.append(usecase_load)
         # screen update about progress of computation
         print('Profile', prof_i+1, '/', num_profiles, 'completed')
-    return(profiles)
+    return profiles
 

--- a/ramp/core/stochastic_process.py
+++ b/ramp/core/stochastic_process.py
@@ -52,7 +52,7 @@ def calc_peak_time_range(user_list, peak_enlarge=0.15):
     return np.arange(peak_time - rand_peak_enlarge, peak_time + rand_peak_enlarge)
 
 
-def stochastic_process(j=None, fname=None, num_profiles=None, day_type=0):
+def stochastic_process(j=None, fname=None, num_profiles=None, day_type=None):
     """Generate num_profiles load profile for the usecase
 
         Covers steps 1. and 2. of the algorithm described in [1], p.6-7
@@ -75,14 +75,24 @@ def stochastic_process(j=None, fname=None, num_profiles=None, day_type=0):
     # and on-peak coincident switch-on probability, corresponds to step 1. of [1], p.6
     peak_time_range = calc_peak_time_range(user_list, peak_enlarge)
 
+    if isinstance(day_type, list):
+        yearly_day_types = day_type
+    else:
+        yearly_day_types = None
+
     for prof_i in range(num_profiles):
         # initialise an empty daily profile (or profile load)
         # that will be filled with the sum of the daily profiles of each User instance
         usecase_load = np.zeros(1440)
+
+        # assign day_type between weekend and weekdays
+        if yearly_day_types is not None:
+            day_type = yearly_day_types[prof_i]
+
         # for each User instance generate a load profile, iterating through all user of this instance and
         # all appliances they own, corresponds to step 2. of [1], p.7
         for user in user_list:
-            user.generate_aggregated_load_profile(prof_i, peak_time_range, day_type)
+            user.generate_aggregated_load_profile(prof_i, peak_time_range, day_type=day_type)
             # aggregate the user load to the usecase load
             usecase_load = usecase_load + user.load
         profiles.append(usecase_load)

--- a/ramp/core/utils.py
+++ b/ramp/core/utils.py
@@ -163,3 +163,12 @@ def random_choice(var, t1, p1, t2, p2):
             duty_cycle(var, t1=t2, p1=p2, t2=t1, p2=p1),
         ]
     )
+
+
+def get_day_type(day):
+    """Given a datetime object return 0 for weekdays or 1 for weekends"""
+    if day.weekday() > 4:
+        answer = 1
+    else:
+        answer = 0
+    return answer

--- a/ramp/core/utils.py
+++ b/ramp/core/utils.py
@@ -1,5 +1,6 @@
 import json
 import random
+import datetime
 import numpy as np
 import pandas as pd
 from openpyxl import load_workbook
@@ -172,3 +173,20 @@ def get_day_type(day):
     else:
         answer = 0
     return answer
+
+
+def yearly_pattern(year=None):
+    """
+    Definition of a yearly pattern of weekends and weekdays, in case some appliances have specific wd/we behaviour
+    If no argument is provided, the pattern always starts a monday and lasts 365 days, otherwise the pattern matches
+    the weekdays and weekends of the provided year
+    """
+    if year is None:
+        year_behaviour = np.zeros(365)
+        year_behaviour[5:365:7] = 1
+        year_behaviour[6:365:7] = 1
+        year_behaviour = year_behaviour.tolist()
+    else:
+        # a list with 0 for weekdays and 1 for weekends
+        year_behaviour = pd.date_range(start=f"{year}-01-01", end=f"{year}-12-31", freq="D").map(get_day_type).to_list()
+    return year_behaviour

--- a/ramp/ramp_convert_old_input_files.py
+++ b/ramp/ramp_convert_old_input_files.py
@@ -20,16 +20,15 @@ parser.add_argument(
 parser.add_argument(
     "-o",
     dest="output_path",
-    nargs=1,
     type=str,
     help="path where to save the converted filename",
 )
 parser.add_argument(
     "--suffix",
     dest="suffix",
-    nargs=1,
     type=str,
     help="suffix appended to the converted filename",
+    default=""
 )
 
 
@@ -49,11 +48,24 @@ def convert_old_user_input_file(
     Imports an input file from a path and returns a processed User_list
     """
 
+    line_to_change = -1
+
     # Check if the lines to save the names of the Appliance instances is already there
+    # And check if the import of the User class is correct, otherwise adapt the file
     with open(fname_path, "r") as fp:
         lines = fp.readlines()
         if "# Code automatically added by ramp_convert_old_input_files.py\n" in lines:
             keep_names = False
+        for i, l in enumerate(lines):
+            if "from core import" in l:
+                line_to_change = i
+        # Change import statement by explicitly naming the full package path
+        lines[line_to_change] = lines[line_to_change].replace("from core import", "from ramp.core.core import")
+
+    # Modify import statement in file
+    if line_to_change != -1:
+        with open(fname_path, "w") as fp:
+            fp.writelines(lines)
 
     # Add code to the input file to assign the variable name of the Appliance instances to their name attribute
     if keep_names is True:
@@ -82,14 +94,6 @@ if __name__ == "__main__":
     fname = args["fname_path"]
     output_path = args.get("output_path")
     suffix = args.get("suffix")
-
-    if output_path is not None:
-        output_path = output_path[0]
-
-    if suffix is None:
-        suffix = ""
-    else:
-        suffix = suffix[0]
 
     if fname is None:
         print("Please provide path to input file with option -i")

--- a/ramp/ramp_run.py
+++ b/ramp/ramp_run.py
@@ -24,28 +24,50 @@ under the License.
 #%% Import required modules
 
 import sys,os
+
+import numpy as np
+
 sys.path.append('../')
 
 try:
+    from .core.utils import get_day_type
     from .core.stochastic_process import stochastic_process
     from .post_process import post_process as pp
 except ImportError:
+    from core.utils import get_day_type
     from core.stochastic_process import stochastic_process
     from post_process import post_process as pp
 
 
-def run_usecase(j=None, fname=None, num_profiles=None):
+def run_usecase(j=None, fname=None, num_profiles=None, days=None):
     # Calls the stochastic process and saves the result in a list of stochastic profiles
-    Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles)
+    if days is None:
+        Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=0)
 
-    # Post-processes the results and generates plots
-    Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
-    pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
+        # Post-processes the results and generates plots
+        Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
+        pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
 
-    pp.export_series(Profiles_series, j, fname)
+        pp.export_series(Profiles_series, j, fname)
 
-    if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
-        pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
+        if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
+            pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
+    else:
+        Profiles_list = []
+        for day in days:
+            print("Day", day)
+            daily_profiles = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=get_day_type(day))
+
+            Profiles_list.append(np.mean(daily_profiles, axis=0))
+
+        # Post-processes the results and generates plots
+        Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
+        pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
+
+        pp.export_series(Profiles_series, j, fname)
+
+        if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
+            pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
 
 
 input_files_to_run = [1, 2, 3]

--- a/ramp/ramp_run.py
+++ b/ramp/ramp_run.py
@@ -39,7 +39,7 @@ except ImportError:
     from post_process import post_process as pp
 
 
-def run_usecase(j=None, fname=None, num_profiles=None, days=None):
+def run_usecase(j=None, fname=None, num_profiles=None, days=None, plot=True):
     # Calls the stochastic process and saves the result in a list of stochastic profiles
     if days is None:
         Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=0)
@@ -59,15 +59,17 @@ def run_usecase(j=None, fname=None, num_profiles=None, days=None):
             daily_profiles = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=get_day_type(day))
 
             Profiles_list.append(np.mean(daily_profiles, axis=0))
+        if plot is True:
+            # Post-processes the results and generates plots
+            Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
+            pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
 
-        # Post-processes the results and generates plots
-        Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)
-        pp.Profile_series_plot(Profiles_series)  # by default, profiles are plotted as a series
+            pp.export_series(Profiles_series, j, fname)
 
-        pp.export_series(Profiles_series, j, fname)
-
-        if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
-            pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
+            if len(Profiles_list) > 1:  # if more than one daily profile is generated, also cloud plots are shown
+                pp.Profile_cloud_plot(Profiles_list, Profiles_avg)
+        else:
+            return Profiles_list
 
 
 input_files_to_run = [1, 2, 3]

--- a/ramp/ramp_run.py
+++ b/ramp/ramp_run.py
@@ -30,11 +30,11 @@ import numpy as np
 sys.path.append('../')
 
 try:
-    from .core.utils import get_day_type
+    from .core.utils import get_day_type, yearly_pattern
     from .core.stochastic_process import stochastic_process
     from .post_process import post_process as pp
 except ImportError:
-    from core.utils import get_day_type
+    from core.utils import get_day_type, yearly_pattern
     from core.stochastic_process import stochastic_process
     from post_process import post_process as pp
 
@@ -42,7 +42,7 @@ except ImportError:
 def run_usecase(j=None, fname=None, num_profiles=None, days=None, plot=True):
     # Calls the stochastic process and saves the result in a list of stochastic profiles
     if days is None:
-        Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=0)
+        Profiles_list = stochastic_process(j=j, fname=fname, num_profiles=num_profiles, day_type=yearly_pattern())
 
         # Post-processes the results and generates plots
         Profiles_avg, Profiles_list_kW, Profiles_series = pp.Profile_formatting(Profiles_list)

--- a/tests/test_input_file_conversion.py
+++ b/tests/test_input_file_conversion.py
@@ -9,7 +9,7 @@ from ramp.ramp_convert_old_input_files import convert_old_user_input_file
 
 
 def load_usecase(j=None, fname=None):
-    peak_enlarge, year_behaviour, user_list, num_profiles = initialise_inputs(
+    peak_enlarge, user_list, num_profiles = initialise_inputs(
         j, fname, num_profiles=1
     )
     return user_list


### PR DESCRIPTION
Fix #11 
Fix #13 

@ismaeel036 
You can call the program for specific date ranges now
`python ramp.py -i ramp/input_files/input_file_4.xlsx -n 3 --start-date 2022-02-01 --end-date 2022-02-04`
Will generate 4 daily profiles which are each obtained by averaging 3 random profiles

If you don't specify start date it will default to january 1st of the same year as the end date.

If you don't specify end date, it will default to december 31st of the same year as the start date

If you provide only `-y 2021` it will generate the whole year 2021 (if you provide the path of a folder with the option `-i` and if that folder contains 12 months, then each folder will be matched with one month)

If you want to get the same sort of outputs you had with previous version of ramp you can just set the `-n` option to 1 instead of 3
